### PR TITLE
v1.03

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 1.03	2017-06-10
 		- Added 'command is not specified' error
+		- Bug fixed for each in perls version older than v5.12 (#2)
 
 1.02	2017-06-06
 		- Bug fixed for each in perls version older than v5.12

--- a/lib/App/nodie.pm
+++ b/lib/App/nodie.pm
@@ -59,14 +59,16 @@ sub main {
 	$arg_exitcodes = $cmdargs->{'--exitcodes'} unless defined($arg_exitcodes);
 	$arg_exitcodes = "" unless defined($arg_exitcodes);
 	my @exitcodes = split(/\s*,\s*/, $arg_exitcodes);
-	while (my $key = each @exitcodes) {
-		my $value = $exitcodes[$key];
+	my %exitcodes = array_to_hash(@exitcodes);
+	while (my $key = each %exitcodes) {
+		my $value = $exitcodes{$key};
 		unless (looks_like_number($value) and $value == int($value) and $value >= 0) {
-			delete $exitcodes[$key];
+			delete $exitcodes{$key};
 			next;
 		}
-		$exitcodes[$key] = int($value);
+		$exitcodes{$key} = int($value);
 	}
+	@exitcodes = values %exitcodes;
 	push @exitcodes, 0, 2 unless @exitcodes;
 	my $arg_log = $cmdargs->{'-l'};
 	$arg_log = $cmdargs->{'--log'} unless defined($arg_log);


### PR DESCRIPTION
- Added 'command is not specified' error
- Bug fixed for each in perls version older than v5.12 (#2)